### PR TITLE
Rename opacity -> transmission distance

### DIFF
--- a/data/main_fields.yaml
+++ b/data/main_fields.yaml
@@ -104,7 +104,7 @@
     - The stored value is without the "Pantone " prefix.
 
 - key: 14
-  name: opacity
+  name: transmission_distance
   type: number
   example: 6.6
   unit: HueForge TD

--- a/docs_src/sample_data/data_to_fill.yaml
+++ b/docs_src/sample_data/data_to_fill.yaml
@@ -11,7 +11,7 @@ data:
     manufactured_date: 1739371290
     netto_full_weight: 1000
     empty_container_weight: 100
-    opacity: 0.2
+    transmission_distance: 0.2
     print_temperature: 210
     preheat_temperature: 170
     bed_temperature: 60

--- a/docs_src/terminology.md
+++ b/docs_src/terminology.md
@@ -29,7 +29,7 @@ Specifies the looks and feel of the filament.
 
 Properties:
 - Color (RGB/RAL/Pantone/...)
-- Opacity
+- Transmission distance
 - Tags (matte, glitter, rainbow, conductive, ...).
 
 ## Material container


### PR DESCRIPTION
We are using HueForge's non-SI  units, the property name should reflect that.