### PR TITLE
Fixed links to openprinttag.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # OpenPrintTag
-This repository contains specification, documentation and utility scripts for the [OpenPrintTag](openprinttag.org) format.
+This repository contains specification, documentation and utility scripts for the [OpenPrintTag](https://openprinttag.org) format.
 
-**This is a "raw" repository, you can access the compiled documentation on [specs.openprinttag.org](specs.openprinttag.org)**
+**This is a "raw" repository, you can access the compiled documentation on [specs.openprinttag.org](https://specs.openprinttag.org)**
 
 (or use generate_docs.sh to generate a website into the docs folder)
 
 ## Directory structure
 * `data`: Machine-readable specification data (field & enum definitions, ...)
-* `docs_src`: Source code for the [specs.openprinttag.org](specs.openprinttag.org) website
+* `docs_src`: Source code for the [specs.openprinttag.org](https://specs.openprinttag.org) website
 * `tests`: Tests
 * `utils`: Reference implementation for the format in Python
 
@@ -24,3 +24,4 @@ cd docs
 python3 -m http.server
 ```
 and open your browser on `127.0.0.1:8000`
+


### PR DESCRIPTION
Links to openprinttag.org are now fixed. Simply adding `https://` was enough and it's not longer redirecting to `https://github.com/prusa3d/OpenPrintTag/blob/main/openprinttag.org` 