### PR TITLE
nit(typos, formatting): fix typos and grammar, add descriptions

### DIFF
--- a/data/aux_fields.yaml
+++ b/data/aux_fields.yaml
@@ -3,7 +3,7 @@
   type: number
   unit: g
   description:
-    - Amount of material that was used up from the container
+    - Amount of material that was used up from the container.
     - "`remaining_weight` = `instance_netto_full_weight` - `consumed_weight`"
 
 - key: 1
@@ -11,7 +11,8 @@
   type: string
   max_length: 8
   description:
-    - Workgroup identifier, used for detecting first usage of the material. See the "write protection" section.
+    - Workgroup identifier, used for detecting first usage of the material.
+    - See the _write protection_ section.
 
 - key: 2
   name: general_purpose_range_user
@@ -20,8 +21,8 @@
   max_length: 8
   description:
     - Determines semantics of the fields in the general purpose key range.
-    - MUST be filled if any of the general purpose keys is used.
-    - See "Vendor-specific fields"
+    - "MUST be filled if any of the general purpose keys is used."
+    - See _Vendor-specific fields_.
 
 - key: 3
   name: last_stir_time

--- a/data/main_fields.yaml
+++ b/data/main_fields.yaml
@@ -3,35 +3,38 @@
   type: uuid
   description:
     - Unique identifier of the package instance.
-    - If not specified, can be deduced from `brand_uuid` + NFC tag UID. See UUID section for more details.
+    - If not specified, can be deduced from `brand_uuid` + NFC tag UID.
+    - See _UUID_ section for more details.
 
 - key: 1
   name: package_uuid
   type: uuid
   description:
     - Universally unique identifier of the package (product)
-    - If not specified, can be deduced from `brand_uuid` + `gtin`. See UUID section for more details.
+    - If not specified, can be deduced from `brand_uuid` + `gtin`.
+    - See _UUID_ section for more details.
 
 - key: 2
   name: material_uuid
   type: uuid
   description:
-    - Universally unique identifier of the material
-    - If not specified, can be deduced from `brand_uuid` + `material_name`. See UUID section for more details.
+    - Universally unique identifier of the material.
+    - If not specified, can be deduced from `brand_uuid` + `material_name`.
+    - See _UUID_ section for more details.
 
 - key: 3
   name: brand_uuid
   type: uuid
   description:
     - Universally unique identifier of the brand
-    - If not specified, can be deduced from the `brand_name` string. See UUID section for more details.
+    - If not specified, can be deduced from the `brand_name` string.
+    - See _UUID_ section for more details.
 
 - key: 4
   name: gtin
   type: number
   required: recommended
-  description:
-    - Global Trade Item Number
+  description: Global Trade Item Number.
 
 - key: 5
   name: brand_specific_instance_id
@@ -46,7 +49,7 @@
   type: string
   max_length: 16
   description:
-    - Brand-specific identifier of the package (product ID)
+    - Brand-specific identifier of the package (product ID).
     - Not much use cases at this moment, possibly just for URL deduction
 
 - key: 7
@@ -54,8 +57,8 @@
   type: string
   max_length: 16
   description:
-    - Together with brand uniquely identifies each material
-    - Not much use cases at this moment, possibly just for URL deduction
+    - Together with brand uniquely identifies each material.
+    - Not much use cases at this moment, possibly just for URL deduction.
 
 - key: 8
   name: material_class
@@ -87,7 +90,7 @@
   required: recommended
   description:
     - Brand-specific material display string/identifier.
-    - In the UI, brand_name + material_name should be displayed together, for example "Prusament PLA Galaxy Black"
+    - In the UI, brand_name + material_name should be displayed together, for example "Prusament PLA Galaxy Black".
 
 - key: 52
   name: material_abbreviation
@@ -95,7 +98,7 @@
   max_length: 7
   example: PCCF
   description:
-    - Abbreviation of the material name, for UI purposes (footers, dashboards, ...)
+    - Abbreviation of the material name, for UI purposes (footers, dashboards, ...).
     - If not present, the material inherits the abbreviation from the material type.
 
 - key: 11
@@ -103,7 +106,7 @@
   type: string
   max_length: 31
   required: recommended
-  description: Brand of the material
+  description: Brand of the material.
   example: Prusament
 
 - key: 12
@@ -113,7 +116,9 @@
   name: write_protection
   type: enum
   items_file: write_protection_enum.yaml
-  description: Indicates whether the tag is write protected (everything except aux section, that one should be always writable). See the "Write protection" section.
+  description:
+    - Indicates whether the tag is write protected (everything except aux section, that one should be always writable).
+    - See the _Write protection_ section.
 
 - key: 14
   name: manufactured_date
@@ -124,7 +129,7 @@
   name: country_of_origin
   type: string
   max_length: 2
-  description: Country the [MaterialPackageInstance](terminology) was produced in, encoded as a two-letter code according to [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
+  description: Country the [MaterialPackageInstance](terminology) was produced in, encoded as a two-letter code according to [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
 
 - key: 15
   name: expiration_date
@@ -137,8 +142,8 @@
   unit: g
   example: 1000
   description:
-    - Nominal/advertised weight of the full package of the material, excluding the container
-    - The actual netto weight of a spcific package instance can slightly differ and is specified by `actual_netto_full_weight`
+    - Nominal/advertised weight of the full package of the material, excluding the container.
+    - The actual netto weight of a specific package instance can slightly differ and is specified by `actual_netto_full_weight`.
 
 - key: 17
   name: actual_netto_full_weight
@@ -169,14 +174,14 @@
   example: 351000
   description:
     - Actual filament length of the full spool.
-    - Can slightly differ from `netto_full_length`
+    - Can slightly differ from `netto_full_length`.
 
 - key: 18
   name: empty_container_weight
   required: recommended
   type: number
   unit: g
-  description: Weight of the empty container
+  description: Weight of the empty container.
 
 - key: 19
   name: primary_color
@@ -197,39 +202,35 @@
   unit: "[R, G, B] or [R, G, B, A]"
   description:
     - One of secondary colors of the material.
-    - Data format is the same as for `primary_color`
+    - Data format is the same as for `primary_color`.
 
 - key: 21
   name: secondary_color_1
   type: bytes
   max_length: 4
   unit: "[R, G, B] or [R, G, B, A]"
-  description:
-    - See `secondary_color_0`
+  description: See `secondary_color_0`.
 
 - key: 22
   name: secondary_color_2
   type: bytes
   max_length: 4
   unit: "[R, G, B] or [R, G, B, A]"
-  description:
-    - See `secondary_color_0`
+  description: See `secondary_color_0`.
 
 - key: 23
   name: secondary_color_3
   type: bytes
   max_length: 4
   unit: "[R, G, B] or [R, G, B, A]"
-  description:
-    - See `secondary_color_0`
+  description: See `secondary_color_0`.
 
 - key: 24
   name: secondary_color_4
   type: bytes
   max_length: 4
   unit: "[R, G, B] or [R, G, B, A]"
-  description:
-    - See `secondary_color_0`
+  description: See `secondary_color_0`.
 
 - key: 25
   deprecated: true
@@ -243,7 +244,8 @@
   example: 6.6
   unit: HueForge TD
   description:
-    - Transmission Distance is a number representing material opacity. Value ranges from 0.1 (least transparent/most opaque) to 100 (most transparent/least opaque)
+    - Transmission Distance is a number representing material opacity.
+    - Value ranges from 0.1 (least transparent/most opaque) to 100 (most transparent/least opaque).
     - See [Prusa TD values](https://help.prusa3d.com/article/hueforge-filament-transparency-values-and-hexcodes_762314) or [HueForge website](https://shop.thehueforge.com/blogs/news/what-is-hueforge).
 
 - key: 28
@@ -260,7 +262,7 @@
   unit: g/cm³ (1 g/cm³ = 0.001 g/mm³ = 1000 kg/m³)
   example: 1.24
   required: recommended
-  description: Density of the material
+  description: Density of the material.
 
 - key: 30
   name: filament_diameter
@@ -282,8 +284,8 @@
   example: 95
   category: fff
   description:
-    - Hardness of the material on the Shore A hardness scale (suitable for softer materials)
-    - "Note: There is no 1:1 mapping between A and D scales, different materials can have different values on one scale even though they are the same on the other."
+    - Hardness of the material on the Shore A hardness scale (suitable for softer materials).
+    - "**Note:** There is no 1:1 mapping between A and D scales, different materials can have different values on one scale even though they are the same on the other."
 
 - key: 32
   name: shore_hardness_d
@@ -291,8 +293,8 @@
   example: 30
   category: fff
   description:
-    - Hardness of the material on the Shore D hardness scale (suitable for harder materials)
-    - "Note: There is no 1:1 mapping between A and D scales, different materials can have different values on one scale even though they are the same on the other."
+    - Hardness of the material on the Shore D hardness scale (suitable for harder materials).
+    - "**Note:** There is no 1:1 mapping between A and D scales, different materials can have different values on one scale even though they are the same on the other."
 
 - key: 33
   name: min_nozzle_diameter
@@ -312,7 +314,7 @@
   required: recommended
   category: fff
   description:
-    - Minimum recommended nozzle tempeature for printing.
+    - Minimum recommended nozzle temperature for printing.
     - Also used for loading the filament to the nozzle.
 
 - key: 35
@@ -323,7 +325,7 @@
   required: recommended
   category: fff
   description:
-    - Maximum recommended nozzle tempeature for printing.
+    - Maximum recommended nozzle temperature for printing.
     - Also used for loading the filament to the nozzle.
 
 - key: 36
@@ -334,7 +336,7 @@
   category: fff
   required: recommended
   description:
-    - Recommended nozzle tempeature for preheating/loadcell bed leveling.
+    - Recommended nozzle temperature for preheating/load cell bed leveling.
     - Should be large enough for the material to get soft, but not low enough for it no to drip out of the nozzle.
 
 - key: 37
@@ -345,7 +347,7 @@
   category: fff
   required: recommended
   description:
-    - Minimum recommended heatbed tempeature.
+    - Minimum recommended heatbed temperature.
 
 - key: 38
   name: max_bed_temperature
@@ -355,7 +357,7 @@
   category: fff
   required: recommended
   description:
-    - Maximum recommended heatbed tempeature.
+    - Maximum recommended heatbed temperature.
 
 - key: 39
   name: min_chamber_temperature
@@ -391,7 +393,7 @@
   example: 75
   category: fff
   description:
-    - Width of the filament spool. Can be useful to know for spool holders, dryboxes and such.
+    - Width of the filament spool. Can be useful to know for spool holders, dry boxes and such.
 
 - key: 43
   name: container_outer_diameter
@@ -400,7 +402,7 @@
   example: 200
   category: fff
   description:
-    - Diameter of the spool. Can be useful to know for spool holders, dryboxes and such.
+    - Diameter of the spool. Can be useful to know for spool holders, dry boxes and such.
 
 - key: 44
   name: container_inner_diameter
@@ -425,14 +427,14 @@
   name: viscosity_18c
   type: number
   unit: mPa·s
-  description: Viscosity of the material at 18 °C
+  description: Viscosity of the material at 18 °C.
   category: sla
 
 - key: 47
   name: viscosity_25c
   type: number
   unit: mPa·s
-  description: Viscosity of the material at 25 °C
+  description: Viscosity of the material at 25 °C.
   category: sla
   example: 80
 
@@ -440,14 +442,14 @@
   name: viscosity_40c
   type: number
   unit: mPa·s
-  description: Viscosity of the material at 40 °C
+  description: Viscosity of the material at 40 °C.
   category: sla
 
 - key: 49
   name: viscosity_60c
   type: number
   unit: mPa·s
-  description: Viscosity of the material at 60 °C
+  description: Viscosity of the material at 60 °C.
   category: sla
 
 - key: 50
@@ -464,4 +466,4 @@
   example: 405
   category: sla
   description:
-    - Wavelength of the light the material has been designed to be cured with
+    - Wavelength of the light the material has been designed to be cured with.

--- a/data/tags_enum.yaml
+++ b/data/tags_enum.yaml
@@ -11,7 +11,7 @@
   name: biocompatible
   category: biological
   display_name: Biocompatible
-  description: Certified biocompatibility (does not cause harmful effects when in contact with the body)
+  description: Certified biocompatibility (does not cause harmful effects when in contact with the body).
 
 - key: 61
   name: home_compostable
@@ -35,13 +35,13 @@
   name: antibacterial
   category: biological
   display_name: Antibacterial
-  description: Has antibacterial properties
+  description: Has antibacterial properties.
 
 - key: 3
   name: air_filtering
   category: biological
   display_name: Air filtering
-  description: Has air filtering properties (absorbs/filters harmful compounds/particles from the air)
+  description: Has air filtering properties (absorbs/filters harmful compounds/particles from the air).
 
 # Physical properties
 # =====================================
@@ -56,14 +56,14 @@
   name: foaming
   category: physical
   display_name: Foaming
-  description: The material increases its volume during extrusion
+  description: The material increases its volume during extrusion.
 
 - key: 67
   name: castable
   category: physical
   display_name: Castable
   description:
-    - The material is suitable to be used as a sacrificial pattern for investement casting.
+    - The material is suitable to be used as a sacrificial pattern for investment casting.
     - It can be cleanly removed from the mold (typically burned out or melted away), leaving minimal residue (for example ashes).
     - This does NOT mean that the material is used for the mold or the final cast itself, only the investment pattern.
 
@@ -85,7 +85,7 @@
   name: radiation_shielding
   category: physical
   display_name: Radiation shielding
-  description: Has radiation shielding properties
+  description: Has radiation shielding properties.
 
 - key: 9
   name: high_temperature
@@ -95,7 +95,7 @@
     - The material softens at higher temperatures than what is common for the material type, while keeping similar printing temperatures.
     - Can be used for HTPLA filament while keeping the PLA material type.
     - This does NOT indicate increase resistance to flame/burning.
-    - "Note: If the material type would be 'HTPLA', adding this tag would mean 'high-temperature variant of a high-temperature PLA'"
+    - "**Note:** If the material type would be 'HTPLA', adding this tag would mean 'high-temperature variant of a high-temperature PLA'"
 
 # Electrical properties
 # ========================================
@@ -116,7 +116,8 @@
   display_name: Conductive
   description:
     - The material can conduct electricity.
-    - This does NOT mean that it the material is a good conductor, such as metals. Common "conductive" material have resistances in the range of kiloohms on 10 cm of filament.
+    - This does NOT mean that it the material is a good conductor, such as metals.
+    - Common "conductive" material have resistances in the range of kiloohms on 10 cm of filament.
     - Sheet resistance R < 1e5 Ω/□ or volumetric resistivity ρ < 1e4 Ω⋅cm.
 
 - key: 70
@@ -141,19 +142,19 @@
   name: water_soluble
   category: chemical
   display_name: Water soluble
-  description: Can be dissolved in water
+  description: Can be dissolved in water.
 
 - key: 14
   name: ipa_soluble
   category: chemical
   display_name: IPA soluble
-  description: Can be dissolved in IPA (isopropylalcohol)
+  description: Can be dissolved in IPA (isopropyl alcohol).
 
 - key: 15
   name: limonene_soluble
   category: chemical
   display_name: Limonene soluble
-  description: Can be dissolved in limonene
+  description: Can be dissolved in limonene.
 
 - key: 64
   name: low_outgassing
@@ -169,14 +170,14 @@
   category: visual
   display_name: Matte
   description:
-    - Produces matte, non-shiny surface (very low specular reflection coefficient)
+    - Produces matte, non-shiny surface (very low specular reflection coefficient).
 
 - key: 17
   name: silk
   category: visual
   display_name: Silk
   description:
-    - Produces smooth, shiny/glossy surface (higher specular reflection coefficient)
+    - Produces smooth, shiny/glossy surface (higher specular reflection coefficient).
 
 - key: 18
   deprecated: true
@@ -187,7 +188,7 @@
   category: visual
   display_name: Translucent
   description:
-   - Not fully opaque – [HueForge TD](https://shop.thehueforge.com/blogs/news/what-is-hueforge) >= X (exact X will be determined later)
+   - Not fully opaque – [HueForge TD](https://shop.thehueforge.com/blogs/news/what-is-hueforge) >= `X` (exact `X` will be determined later).
    - The material with this tag can possibly disperse light, meaning that while the light goes through it, the image is "blurred" and one does not see clearly what's on the other side. See the `transparent` tag.
 
 - key: 20
@@ -205,15 +206,15 @@
   display_name: Without pigments
   hints: [translucent]
   description:
-    - The material is of its "natural" color, no pigments were added
+    - The material is of its "natural" color, no pigments were added.
 
 - key: 21
   name: iridescent
   category: visual
   display_name: Iridescent
   description:
-    - Same as mystic
-    - Changes color based on the viewing angle
+    - Same as mystic.
+    - Changes color based on the viewing angle.
     - See https://en.wikipedia.org/wiki/Iridescence
 
 - key: 22
@@ -222,7 +223,7 @@
   display_name: Pearlescent
   implies: [iridescent]
   description:
-    - Special case of iridescent where the reflected light is mostly white
+    - Special case of iridescent where the reflected light is mostly white.
     - See https://en.wikipedia.org/wiki/Iridescence#Pearlescence
 
 - key: 23
@@ -231,7 +232,7 @@
   display_name: Glitter
   description:
     - Contains coarse glitter particles, causing a shimmering effect.
-    - Similar to iridescent/pearlescent, but the individual particles causing the effect are larger, visible with the naked eye
+    - Similar to iridescent/pearlescent, but the individual particles causing the effect are larger, visible with the naked eye.
 
 - key: 24
   name: glow_in_the_dark
@@ -239,7 +240,7 @@
   display_name: Glow in the dark
   description:
     - Glows in the dark (phosphorescent).
-    - The glow color doesn't necessarily match the base material color (`illuminescent_color_change`)
+    - The glow color doesn't necessarily match the base material color (`illuminescent_color_change`).
     - The different glow color can be specified as secondary color of the material.
 
 - key: 25
@@ -247,8 +248,8 @@
   category: visual
   display_name: Neon
   description:
-    - Neon color/glows under UV light (fluorescent)
-    - The glow color doesn't necessarily match the base material color (`illuminescent_color_change`)
+    - Neon color/glows under UV light (fluorescent).
+    - The glow color doesn't necessarily match the base material color (`illuminescent_color_change`).
     - The different glow color can be specified as secondary color of the material.
 
 - key: 26
@@ -273,7 +274,7 @@
   display_name: Gradual color change
   description:
     - Transitions between colors as the filament is extruded.
-    - Does not necessary mean that the filament must go through the rainbow colors, gradual color change between two colors is enough to qualify
+    - Does not necessary mean that the filament must go through the rainbow colors, gradual color change between two colors is enough to qualify.
 
 - key: 29
   name: coextruded
@@ -281,7 +282,7 @@
   display_name: Coextruded
   description:
     - Co-extruded from multiple colors. The colors are all present at any cross-section of the filament.
-    - Do not confuse with `gradual_color_change`
+    - Do not confuse with `gradual_color_change`.
     - Does not have a primary color, number of colors can be derived from the defined secondary colors.
 
 # Materials
@@ -292,7 +293,7 @@
   category: additives_other
   display_name: Contains carbon
   description:
-    - Contains carbon
+    - Contains carbon.
 
 - key: 31
   name: contains_carbon_fiber
@@ -300,7 +301,7 @@
   display_name: Contains carbon fiber
   implies: [contains_carbon]
   description:
-    - Contains carbon fibers
+    - Contains carbon fibers.
 
 - key: 32
   name: contains_carbon_nano_tubes
@@ -315,7 +316,7 @@
   category: additives_other
   display_name: Contains glass
   description:
-    - Contains glass
+    - Contains glass.
 
 - key: 34
   name: contains_glass_fiber
@@ -323,19 +324,21 @@
   display_name: Contains glass fiber
   implies: [contains_glass]
   description:
-    - Contains glass fibers
+    - Contains glass fibers.
 
 - key: 35
   name: contains_kevlar
   category: additives_other
   display_name: Contains Kevlar
   description:
-    - Contains kevlar (aramid)
+    - Contains kevlar (aramid).
 
 - key: 68
   name: contains_ptfe
   category: additives_other
   display_name: Contains PTFE
+  description:
+    - Contains polytetrafluoroethylene (PTFE).
 
 # Minerals
 
@@ -344,12 +347,16 @@
   category: additives_other
   display_name: Contains stone
   hints: [abrasive]
+  description:
+    - Contains stone.
 
 - key: 37
   name: contains_magnetite
   category: additives_other
   display_name: Contains magnetite
   hints: [abrasive]
+  description:
+    - Contains magnetite.
 
 # Organics
 
@@ -357,42 +364,49 @@
   name: contains_organic_material
   category: additives_organic
   display_name: Contains organic material
+  description: Contains organic material.
 
 - key: 39
   name: contains_cork
   category: additives_organic
   display_name: Contains cork
   implies: [contains_organic_material]
+  description: Contains cork.
 
 - key: 40
   name: contains_wax
   category: additives_organic
   display_name: Contains wax
   implies: [contains_organic_material]
+  description: Contains wax.
 
 - key: 41
   name: contains_wood
   category: additives_organic
   display_name: Contains wood
   implies: [contains_organic_material]
+  description: Contains wood.
 
 - key: 66
   name: contains_algae
   category: additives_organic
   display_name: Contains algae
   implies: [contains_organic_material]
+  description: Contains algae.
 
 - key: 42
   name: contains_bamboo
   category: additives_organic
   display_name: Contains bamboo
   implies: [contains_wood]
+  description: Contains bamboo.
 
 - key: 43
   name: contains_pine
   category: additives_organic
   display_name: Contains pine
   implies: [contains_wood]
+  description: Contains pine.
 
 # Ceramic
 
@@ -401,6 +415,7 @@
   category: additives_other
   display_name: Contains ceramic
   hints: [abrasive]
+  description: Contains ceramic.
 
 - key: 45
   name: contains_boron_carbide
@@ -408,6 +423,7 @@
   display_name: Contains boron carbide
   implies: [contains_ceramic]
   hints: [radiation_shielding]
+  description: Contains boron carbide (useful for radiation shielding).
 
 # Metals
 
@@ -423,18 +439,21 @@
   category: additives_metal
   display_name: Contains bronze
   implies: [contains_metal]
+  description: Contains bronze.
 
 - key: 48
   name: contains_iron
   category: additives_metal
   display_name: Contains iron
   implies: [contains_metal]
+  description: Contains iron.
 
 - key: 49
   name: contains_steel
   category: additives_metal
   display_name: Contains steel
   implies: [contains_metal]
+  description: Contains steel.
 
 - key: 50
   name: contains_silver
@@ -442,24 +461,28 @@
   display_name: Contains silver
   implies: [contains_metal]
   hints: [antibacterial]
+  description: Contains silver (useful for antibacterial properties).
 
 - key: 51
   name: contains_copper
   category: additives_metal
   display_name: Contains copper
   implies: [contains_metal]
+  description: Contains copper.
 
 - key: 52
   name: contains_aluminium
   category: additives_metal
   display_name: Contains aluminium
   implies: [contains_metal]
+  description: Contains aluminium.
 
 - key: 53
   name: contains_brass
   category: additives_metal
   display_name: Contains brass
   implies: [contains_metal]
+  description: Contains brass.
 
 - key: 54
   name: contains_tungsten
@@ -476,25 +499,25 @@
   name: imitates_wood
   category: imitation
   display_name: Imitates wood
-  description: Imitates wood
+  description: Imitates wood.
 
 - key: 56
   name: imitates_metal
   category: imitation
   display_name: Imitates metal
-  description: Imitates metal
+  description: Imitates metal.
 
 - key: 57
   name: imitates_marble
   category: imitation
   display_name: Imitates marble
-  description: Imitates marble
+  description: Imitates marble.
 
 - key: 58
   name: imitates_stone
   category: imitation
   display_name: Imitates stone
-  description: Imitates stone
+  description: Imitates stone.
 
 # Other
 # =====================================
@@ -503,16 +526,16 @@
   name: lithophane
   category: other
   display_name: Lithophane
-  description: Specifically designed for lithophaning
+  description: Specifically designed for lithophaning.
 
 - key: 60
   name: recycled
   category: other
   display_name: Recycled
-  description: Part of the material is recycled
+  description: Part of the material is recycled.
 
 - key: 69
   name: limited_edition
   category: other
   display_name: Limited edition
-  description: The material is a limited edition run
+  description: The material is a limited edition run.


### PR DESCRIPTION
## Summary
This PR fixes a few spelling typos.
Further, it changes the description fields in several types.

## Details
I set out a few basic guiding _personal_ rules:
- Every sentence should end with a `.` unless the last part of the text belongs to a raw URL.
- When the description is split into separate lines, each sentence should be dedicated to its own line.
- Single sentence descriptions should prefer string, not list, layouts, unless they are too long.
- Every key _should_ have a description, even if it is repetitive of its display name.
- Markdown should be used to its maximum extent where relevant.
- References to other keys should use the Markdown code blocks.
- References to documentation sections should be italicized.
- Notes should be bolded.
- Well-defined wording should be preferred (isopropylalcohol -> isopropyl alcohol)

Since this makes many assumptions, I am willing to more clearly define them, use the maintainers' preferred ones, submit only typo fixes, or draft a style guide. I think it might be helpful to have a spellchecking workflow for `data`.


<details> 
  <summary><h2>Further explanation<h2></summary>
   
It's a bit biased to follow the way I've been interpreting them to code-generate Rust documentation strings from the schema:

https://github.com/johnlettman/openprinttag-rs/blob/c243e03a57c58fb045934eda3ece231d4d5f7a21/openprinttag-codegen/src/de/description.rs#L14-L19

Setting out a few rules can make this process fairly deterministic. In particular, conventions like wrapping tag references in code blocks could denote automatic resolution for docstrings or other functions.


### Single string
```yaml
description: Hello world
```

_becomes_

```rust
/// Hello world
```

### List of strings
```yaml
description:
  - Hello world.
  - This is my enum tag!
```

_becomes_

```rust
/// Hello world.
///
/// This is my enum tag!
```

</details>








