### PR TITLE
feat(color-type): add `color_rgba` type (#88)

### DIFF
--- a/data/main_fields.yaml
+++ b/data/main_fields.yaml
@@ -185,10 +185,8 @@
 
 - key: 19
   name: primary_color
-  type: bytes
-  max_length: 4
+  type: color_rgba
   required: recommended
-  unit: "[R, G, B] or [R, G, B, A]"
   example: "`\\xff\\x00\\x00\\x7f`"
   description:
     - Primary color of the material in the RGB(A) format, intended for UI purposes.
@@ -197,39 +195,29 @@
 
 - key: 20
   name: secondary_color_0
-  type: bytes
-  max_length: 4
-  unit: "[R, G, B] or [R, G, B, A]"
+  type: color_rgba
   description:
     - One of secondary colors of the material.
     - Data format is the same as for `primary_color`.
 
 - key: 21
   name: secondary_color_1
-  type: bytes
-  max_length: 4
-  unit: "[R, G, B] or [R, G, B, A]"
+  type: color_rgba
   description: See `secondary_color_0`.
 
 - key: 22
   name: secondary_color_2
-  type: bytes
-  max_length: 4
-  unit: "[R, G, B] or [R, G, B, A]"
+  type: color_rgba
   description: See `secondary_color_0`.
 
 - key: 23
   name: secondary_color_3
-  type: bytes
-  max_length: 4
-  unit: "[R, G, B] or [R, G, B, A]"
+  type: color_rgba
   description: See `secondary_color_0`.
 
 - key: 24
   name: secondary_color_4
-  type: bytes
-  max_length: 4
-  unit: "[R, G, B] or [R, G, B, A]"
+  type: color_rgba
   description: See `secondary_color_0`.
 
 - key: 25

--- a/docs_src/nfc_data_format.md
+++ b/docs_src/nfc_data_format.md
@@ -84,6 +84,7 @@
 1. `enum_array` fields are encoded as CBOR arrays of integers, according to the field mapping
 1. `timestamp` fields are encoded as UNIX timestamp integers
 1. `bytes` and `uuid` types are encoded as CBOR byte string (type 2)
+1. `color_rgba` fields are encoded as a CBOR byte string (type 2) with 3 to 4 bytes representing `[R, G, B]` or `[R, G, B, A]` values
 1. `number` types can be encoded as either unsigned integers (type 0), signed integers (type 1), half floats or floats
 1. `string` types are encoded as CBOR text string (type 3, UTF-8 is enforced by the CBOR specification)
 1. The `X` in the `string:X` or `bytes:X` notation defines maximum permissible length of the data in bytes.

--- a/utils/fields.py
+++ b/utils/fields.py
@@ -189,6 +189,15 @@ class BytesField(Field):
         return result
 
 
+class ColorRGBAField(BytesField):
+    def __init__(self, config, config_dir):
+        if "max_length" not in config:
+            # default to RGBA, but
+            # leave the door open for RGB or other formats in the future
+            config["max_length"] = 4
+        super().__init__(config, config_dir)
+
+
 class UUIDField(Field):
     def decode(self, data):
         return str(uuid.UUID(bytes=data))
@@ -206,6 +215,7 @@ field_types = {
     "enum_array": EnumArrayField,
     "timestamp": IntField,
     "bytes": BytesField,
+    "color_rgba": ColorRGBAField,
     "uuid": UUIDField,
 }
 


### PR DESCRIPTION
This PR adds the `color` type, a simple alias to `bytes` with a (default) `max_length` of 4.

The more explicit use of `color` as a type can signal to implementing libraries that the data within the field could be interpreted as a color.

This can enable features such as encoding or displaying the color in a different format, performing color operations, and so on.

Closes #88.