### PR TITLE
Fix UnicodeDecodeError on windows

### DIFF
--- a/docs_src/generate.py
+++ b/docs_src/generate.py
@@ -11,8 +11,8 @@ def gen_material_tag_table():
     r.write("<table>")
     r.write("<tr><th>ID</th><th>Name</th><th>Display name</th><th>Info</th>")
 
-    tags = yaml.safe_load(open(os.path.join(vars.data_dir, "tags_enum.yaml"), "r"))
-    categories = yaml.safe_load(open(os.path.join(vars.data_dir, "tag_categories_enum.yaml"), "r"))
+    tags = yaml.safe_load(open(os.path.join(vars.data_dir, "tags_enum.yaml"), "r", encoding="utf-8"))
+    categories = yaml.safe_load(open(os.path.join(vars.data_dir, "tag_categories_enum.yaml"), "r", encoding="utf-8"))
 
     categories_keys = {c["name"] for c in categories}
 

--- a/docs_src/generate_common.py
+++ b/docs_src/generate_common.py
@@ -109,7 +109,7 @@ def show_file(file, language="yaml"):
     r.write(f"> ```bash\n> cat {file}\n> ```\n\n")
 
     r.write("<details><summary><b>Commmand output</b></summary>\n\n")
-    with open(f"{dir}/{file}", "r") as f:
+    with open(f"{dir}/{file}", "r", encoding="utf-8") as f:
         r.write(f"```{language}\n{f.read()}\n```\n")
     r.write("</details>\n\n")
 

--- a/docs_src/tables.py
+++ b/docs_src/tables.py
@@ -59,7 +59,7 @@ class Column(typing.NamedTuple):
 
 
 def generate_table(yaml_file: str, columns: typing.List[Column], filter: any = None):
-    src = open(yaml_file, "r")
+    src = open(yaml_file, "r", encoding="utf-8")
     data = yaml.safe_load(src)
 
     tgt = io.StringIO("")

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -106,7 +106,7 @@ for file in tests_dir.glob("encode_decode/*_input.yaml"):
     init_args = ["--size=312", "--aux-region=32"]
     info_args = ["--validate", "--show-all", "--show-raw-data", "--opt-check"]
 
-    with open(file, "r") as f:
+    with open(file, "r", encoding="utf-8") as f:
         yml = yaml.safe_load(f).get("test_config", {})
 
         if uri := yml.get("uri"):

--- a/utils/fields.py
+++ b/utils/fields.py
@@ -105,7 +105,7 @@ class EnumFieldBase(Field):
         self.items_by_key = dict()
         self.items_by_name = dict()
 
-        self.items_yaml = yaml.safe_load(open(os.path.join(config_dir, config["items_file"]), "r"))
+        self.items_yaml = yaml.safe_load(open(os.path.join(config_dir, config["items_file"]), "r", encoding="utf-8"))
         for item in self.items_yaml:
             if item.get("deprecated", False):
                 continue
@@ -239,7 +239,7 @@ class Fields:
 
     def from_file(file: str):
         r = Fields()
-        r.init_from_yaml(yaml.safe_load(open(file, "r")), os.path.dirname(file))
+        r.init_from_yaml(yaml.safe_load(open(file, "r", encoding="utf-8")), os.path.dirname(file))
 
         return r
 

--- a/utils/nfc_initialize.py
+++ b/utils/nfc_initialize.py
@@ -41,7 +41,7 @@ class Args:
 
 def nfc_initialize(args: Args):
     config_dir = os.path.dirname(args.config_file)
-    with open(args.config_file, "r") as f:
+    with open(args.config_file, "r", encoding="utf-8") as f:
         config = types.SimpleNamespace(**yaml.safe_load(f))
 
     assert config.root == "nfcv", "nfc_initialize only supports NFC-V tags"

--- a/utils/rec_info.py
+++ b/utils/rec_info.py
@@ -100,7 +100,7 @@ if args.validate:
         region.fields.validate(region.read())
 
 if args.extra_required_fields:
-    with open(args.extra_required_fields, "r") as f:
+    with open(args.extra_required_fields, "r", encoding="utf-8") as f:
         req_fields = yaml.safe_load(f)
 
     for region_name, region_req_fields in req_fields.items():

--- a/utils/rec_update.py
+++ b/utils/rec_update.py
@@ -18,7 +18,7 @@ record = Record(args.config_file, memoryview(bytearray(sys.stdin.buffer.read()))
 record.encode_config.canonical = args.canonical
 record.encode_config.indefinite_containers = args.indefinite_containers
 
-update_data = yaml.safe_load(open(args.update_data, "r"))
+update_data = yaml.safe_load(open(args.update_data, "r", encoding="utf-8"))
 for region_name, region in record.regions.items():
     region.update(
         update_fields=update_data.get("data", dict()).get(region_name, dict()),

--- a/utils/record.py
+++ b/utils/record.py
@@ -102,7 +102,7 @@ class Record:
         self.encode_config = EncodeConfig()
 
         self.config_dir = os.path.dirname(config_file)
-        with open(config_file, "r") as f:
+        with open(config_file, "r", encoding="utf-8") as f:
             self.config = types.SimpleNamespace(**yaml.safe_load(f))
 
         # Decode the root and find payload


### PR DESCRIPTION
Explicitly set utf8 encoding for `open`.

--
Fixes errors like `UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 3894: character maps to <undefined>` when calling `rec_update.py` for example
--

I thought I was going crazy and quadruple checked my service if it does something stupid.
Turns out it's windows again (of course) - the encoding is not utf8 per default.
I'm not sure if this is a win specific issue but I think in general it doesn't hurt to explicitly set the encoding.

I just did it for all `open` calls now.

Another solution would be to use `PYTHONUTF8=1` env var (checked it, works as well) - this should be then mentioned with a big fat ⚠️ 😅 