### PR TITLE
fix(workflows): do not run "Trigger GitLab Pipeline" in forks

### DIFF
--- a/.github/workflows/gitlab-trigger.yml
+++ b/.github/workflows/gitlab-trigger.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   trigger-gitlab-deployment:
     runs-on: ubuntu-latest
+    if: github.repository == 'prusa3d/OpenPrintTag'
     steps:
       - name: Send trigger to WebDev GitLab
         run: |


### PR DESCRIPTION
This resolves a small issue where the "Trigger GitLab Pipeline" workflow will execute inside of forks that do not have access to the `GITLAB_TRIGGER_TOKEN` inside the `prusa3d/OpenPrintTag` repository

Example:
https://github.com/johnlettman/pr-prusa3d-openprinttag/actions/runs/19679566252

The resolution is a simple `if` check of the current repository to determine whether it is not in a fork.