### PR TITLE
Add storage_location aux field

### DIFF
--- a/data/aux_fields.yaml
+++ b/data/aux_fields.yaml
@@ -31,3 +31,12 @@
   description:
     - Timestamp when the resin was last stirred.
     - Resins that have not been used for some time should be stirred before printing.
+
+- key: 4
+  name: storage_location
+  type: string
+  example: Shelf B3
+  max_length: 8
+  description:
+    - Free-form identifier for the physical storage location of the container.
+    - Intended for inventory management workflows (e.g. "Shelf B3", "DB2/S4").

--- a/utils/schema/fields.schema.json
+++ b/utils/schema/fields.schema.json
@@ -209,6 +209,9 @@
                 },
                 "last_stir_time": {
                     "$ref": "field_types.schema.json#/definitions/timestamp"
+                },
+                "storage_location": {
+                    "$ref": "field_types.schema.json#/definitions/string"
                 }
             },
             "unevaluatedProperties": false


### PR DESCRIPTION
Add an optional free-form string field to the auxiliary region for recording the physical storage location of a container (e.g. shelf, rack, drybox, bin). This supports inventory-management use cases that are currently only possible via the vendor/general-purpose key range, which is opaque across tools.

The field is uncategorized so it applies to any material class, and capped at 8 characters to balance usefulness against aux-region space. Semantics are deliberately free-form - no hierarchy is imposed by the spec - so applications can layer their own structure (building/room/shelf, etc.) on top without a schema change.

Changes:
- data/aux_fields.yaml: add key 4, storage_location
- utils/schema/fields.schema.json: add matching aux property so unevaluatedProperties: false does not reject it