### PR TITLE
Increase max_length for the material_name field

### DIFF
--- a/data/main_fields.yaml
+++ b/data/main_fields.yaml
@@ -85,7 +85,7 @@
 - key: 10
   name: material_name
   type: string
-  max_length: 31
+  max_length: 63
   example: PC Blend Carbon Fiber Black
   required: recommended
   description:


### PR DESCRIPTION
The openprinttag-database currently contains 1655 materials with name longer than actual limit of 31 bytes.
We want to keep the limit somehow round-number to allow for static buffer allocation.

That is why I am **suggesting 47 bytes** (48 with null termination). This statistics looks much better with for the limit of 47 bytes: Just 193 materials and most of them could be easily shortened to fit if needed.

I have also considered 63 bytes, which leaves only 16 materials with too long name. But this might be already impractical when the field is send with additional bytes.

I am attaching full histogram of `material_name` lengths from the database:

<img width="1600" height="600" alt="histogram" src="https://github.com/user-attachments/assets/d1d9d1a0-a2be-4848-b400-82552f5265ff" />

Here are few examples of materials, which would not fit even when this gets approved (

 - `Panchroma™ Dual Matte PLA Chameleon (Teal-Yellow)`
 - `PLA Temperature Color Change Black To Red To Yellow`
 - `Pearlescent Translucent Neon Green PETG PRO v2 - UV Reactive`
 - `ABS Color Change Green to Yellow (Heat Activated)`
 - `Sculpt-High Temperature Resistant Resin Ultra White`
 - `Filaflex 95 Foamy Footwearology edition Lavender`
 - `Pink Grapefruit: High Temperature Virgin PET-G with Sparkles`
 - `Magic Silk PLA Tarnished Copper (Gunmetal Gray / Copper)`
 - `Rapid PLA Gradient Thistle Purple & Ethereal Blue`

