### PR TITLE
chore: update GitHub Actions to v6 to fix Node.js 20 deprecation warning

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,6 +9,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
     - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/test-schemas.yml
+++ b/.github/workflows/test-schemas.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/docs_src/index.html
+++ b/docs_src/index.html
@@ -15,7 +15,7 @@
   <script>
     window.$docsify = {
       name: "OpenPrintTag",
-      repo: "//github.com/prusa3d/OpenPrintTag",
+      repo: "//github.com/OpenPrintTag/openprinttag-specification",
       loadSidebar: true,
       loadNavbar: true,
       subMaxLevel: 3,


### PR DESCRIPTION
   - Upgrade actions/checkout and actions/setup-python from v3/v4/v5 to v6 across all workflow files.
   - update documentation repository in index.html