### PR TITLE
rec_info: Add show-field-info

### DIFF
--- a/tests/encode_decode/01_info.yaml
+++ b/tests/encode_decode/01_info.yaml
@@ -4,16 +4,48 @@ regions:
     absolute_offset: 66
     size: 4
     used_size: 4
+    field_used_size:
+      aux_region_offset: 3
   main:
     payload_offset: 4
     absolute_offset: 70
     size: 206
     used_size: 176
+    field_used_size:
+      gtin: 10
+      brand_specific_instance_id: 12
+      material_class: 2
+      material_type: 2
+      material_name: 24
+      brand_name: 11
+      manufactured_date: 6
+      nominal_netto_full_weight: 4
+      actual_netto_full_weight: 4
+      empty_container_weight: 4
+      primary_color: 6
+      tags: 5
+      density: 5
+      min_print_temperature: 4
+      max_print_temperature: 4
+      preheat_temperature: 4
+      min_bed_temperature: 4
+      max_bed_temperature: 4
+      min_chamber_temperature: 3
+      max_chamber_temperature: 4
+      chamber_temperature: 3
+      container_width: 4
+      container_outer_diameter: 4
+      container_inner_diameter: 4
+      container_hole_diameter: 4
+      certifications: 6
+      primary_color_lab: 15
+      primary_color_ral: 12
   aux:
     payload_offset: 210
     absolute_offset: 276
     size: 35
     used_size: 1
+    field_used_size: {}
 root:
   cc_capacity: 312
   ndef_tlv_payload_start: 8

--- a/tests/encode_decode/02_info.yaml
+++ b/tests/encode_decode/02_info.yaml
@@ -4,16 +4,45 @@ regions:
     absolute_offset: 66
     size: 4
     used_size: 4
+    field_used_size:
+      aux_region_offset: 3
   main:
     payload_offset: 4
     absolute_offset: 70
     size: 206
     used_size: 135
+    field_used_size:
+      gtin: 10
+      brand_specific_instance_id: 12
+      material_class: 2
+      material_type: 2
+      material_name: 16
+      brand_name: 11
+      manufactured_date: 6
+      nominal_netto_full_weight: 4
+      actual_netto_full_weight: 4
+      empty_container_weight: 4
+      primary_color: 5
+      tags: 4
+      density: 5
+      min_print_temperature: 4
+      max_print_temperature: 5
+      preheat_temperature: 4
+      min_bed_temperature: 4
+      max_bed_temperature: 4
+      min_chamber_temperature: 3
+      max_chamber_temperature: 4
+      chamber_temperature: 4
+      container_width: 4
+      container_outer_diameter: 4
+      container_inner_diameter: 4
+      container_hole_diameter: 4
   aux:
     payload_offset: 210
     absolute_offset: 276
     size: 35
     used_size: 1
+    field_used_size: {}
 root:
   cc_capacity: 312
   ndef_tlv_payload_start: 8

--- a/tests/encode_decode/04_info.yaml
+++ b/tests/encode_decode/04_info.yaml
@@ -4,16 +4,45 @@ regions:
     absolute_offset: 56
     size: 4
     used_size: 4
+    field_used_size:
+      aux_region_offset: 3
   main:
     payload_offset: 4
     absolute_offset: 60
     size: 216
     used_size: 148
+    field_used_size:
+      material_class: 2
+      material_type: 2
+      material_name: 28
+      brand_name: 9
+      manufactured_date: 6
+      nominal_netto_full_weight: 4
+      actual_netto_full_weight: 4
+      empty_container_weight: 4
+      primary_color: 5
+      tags: 9
+      density: 5
+      min_nozzle_diameter: 5
+      min_print_temperature: 5
+      max_print_temperature: 5
+      min_bed_temperature: 4
+      max_bed_temperature: 4
+      min_chamber_temperature: 4
+      max_chamber_temperature: 4
+      chamber_temperature: 4
+      container_width: 4
+      container_outer_diameter: 4
+      container_inner_diameter: 4
+      container_hole_diameter: 4
+      material_abbreviation: 10
+      actual_full_length: 7
   aux:
     payload_offset: 220
     absolute_offset: 276
     size: 35
     used_size: 1
+    field_used_size: {}
 root:
   cc_capacity: 312
   ndef_tlv_payload_start: 8

--- a/tests/encode_decode/05_info.yaml
+++ b/tests/encode_decode/05_info.yaml
@@ -4,16 +4,23 @@ regions:
     absolute_offset: 42
     size: 4
     used_size: 4
+    field_used_size:
+      aux_region_offset: 3
   main:
     payload_offset: 4
     absolute_offset: 46
     size: 230
     used_size: 31
+    field_used_size:
+      material_class: 2
+      transmission_distance: 7
+      tags: 8
   aux:
     payload_offset: 234
     absolute_offset: 276
     size: 35
     used_size: 1
+    field_used_size: {}
 root:
   cc_capacity: 312
   ndef_tlv_payload_start: 8

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -104,7 +104,7 @@ for file in tests_dir.glob("encode_decode/*_input.yaml"):
     fn_info = f"{fn_base}_info.yaml"
 
     init_args = ["--size=312", "--aux-region=32"]
-    info_args = ["--validate", "--show-all", "--show-raw-data", "--opt-check"]
+    info_args = ["--validate", "--show-all", "--opt-check"]
 
     with open(file, "r", encoding="utf-8") as f:
         yml = yaml.safe_load(f).get("test_config", {})
@@ -151,14 +151,14 @@ if True:
     utils_test(
         init_args=["--size=312", "--aux-region=32"],
         update_args=[f"{tests_dir}/specific/unknown_data.yaml", f"--config-file={tests_dir}/specific/unknown_config.yaml"],
-        info_args=["--show-all", "--show-raw-data"],
+        info_args=["--show-all"],
         expected_info_fn=f"{tests_dir}/specific/unknown_info_1.yaml",
         expected_data_fn=f"{tests_dir}/specific/unknown_data_1.bin",
     )
     utils_test(
         input_fn=f"{tests_dir}/specific/unknown_data_1.bin",
         update_args=[f"{tests_dir}/specific/unknown_update_data.yaml"],
-        info_args=["--show-all", "--show-raw-data"],
+        info_args=["--show-all"],
         expected_info_fn=f"{tests_dir}/specific/unknown_info_2.yaml",
         expected_data_fn=f"{tests_dir}/specific/unknown_data_2.bin",
     )

--- a/tests/specific/unknown_info_1.yaml
+++ b/tests/specific/unknown_info_1.yaml
@@ -4,16 +4,20 @@ regions:
     absolute_offset: 42
     size: 4
     used_size: 4
+    field_used_size:
+      aux_region_offset: 3
   main:
     payload_offset: 4
     absolute_offset: 46
     size: 230
     used_size: 19
+    field_used_size: {}
   aux:
     payload_offset: 234
     absolute_offset: 276
     size: 35
     used_size: 1
+    field_used_size: {}
 root:
   cc_capacity: 312
   ndef_tlv_payload_start: 8

--- a/tests/specific/unknown_info_2.yaml
+++ b/tests/specific/unknown_info_2.yaml
@@ -4,16 +4,21 @@ regions:
     absolute_offset: 42
     size: 4
     used_size: 4
+    field_used_size:
+      aux_region_offset: 3
   main:
     payload_offset: 4
     absolute_offset: 46
     size: 230
     used_size: 21
+    field_used_size:
+      material_class: 2
   aux:
     payload_offset: 234
     absolute_offset: 276
     size: 35
     used_size: 1
+    field_used_size: {}
 root:
   cc_capacity: 312
   ndef_tlv_payload_start: 8

--- a/utils/rec_info.py
+++ b/utils/rec_info.py
@@ -15,12 +15,13 @@ from record import Record
 parser = argparse.ArgumentParser(prog="rec_info", description="Reads a record from the STDIN and prints various information about it in the YAML format")
 parser.add_argument("-c", "--config-file", type=str, default=default_config_file, help="Record configuration YAML file")
 parser.add_argument("-r", "--show-region-info", action=argparse.BooleanOptionalAction, default=False, help="Print information about regions")
+parser.add_argument("--show-field-info", action=argparse.BooleanOptionalAction, default=False, help="Show per-field used size (including key). Please note that due to cbor2 constraints, the values represent the field size this utility would re-encode into, not the actual data encoded size.")
 parser.add_argument("-u", "--show-root-info", action=argparse.BooleanOptionalAction, default=False, help="Print general info about the NFC tag")
 parser.add_argument("-d", "--show-data", action=argparse.BooleanOptionalAction, default=False, help="Parse and print region data")
 parser.add_argument("-b", "--show-raw-data", action=argparse.BooleanOptionalAction, default=False, help="Print raw region data (HEX)")
 parser.add_argument("-m", "--show-meta", action=argparse.BooleanOptionalAction, default=False, help="By default, --show-data hides the meta region. Enabling this option will print it, too.")
 parser.add_argument("-i", "--show-uri", action=argparse.BooleanOptionalAction, default=False, help="If a URI NDEF record is present, report it as well.")
-parser.add_argument("-a", "--show-all", action=argparse.BooleanOptionalAction, default=False, help="Apply all --show options")
+parser.add_argument("-a", "--show-all", action=argparse.BooleanOptionalAction, default=False, help="Apply (almost) all --show options")
 parser.add_argument("-v", "--validate", action=argparse.BooleanOptionalAction, default=False, help="Check that the data are valid")
 parser.add_argument("-f", "--extra-required-fields", type=str, default=None, help="Check that all fields from the specified YAML file are present in the record")
 parser.add_argument("--unhex", action=argparse.BooleanOptionalAction, default=False, help="Interpret the stdin as a hex string instead of raw bytes")
@@ -30,9 +31,11 @@ parser.add_argument("--tag-uid", type=str, default=None, help="UID of the tag fo
 args = parser.parse_args()
 
 if args.show_all:
-    args.show_root_info = True
     args.show_region_info = True
+    args.show_field_info = True
+    args.show_root_info = True
     args.show_data = True
+    args.show_raw_data = True
     args.show_meta = True
     args.show_uri = True
 
@@ -56,9 +59,20 @@ if args.show_region_info or args.show_root_info:
     for name, region in record.regions.items():
         region_info = region.info_dict()
         payload_used_size += region.used_size()
+
+        if args.show_field_info:
+            field_sizes = dict()
+
+            base_len = len(region.fields.update())
+
+            for key, value in region.read(out_unknown_fields=dict()).items():
+                field_sizes[key] = len(region.fields.update(update_fields={key: value})) - base_len
+
+            region_info["field_used_size"] = field_sizes
+
         regions_info[name] = region_info
 
-    if args.show_region_info:
+    if args.show_region_info or args.show_field_info:
         output["regions"] = regions_info
 
     if args.show_root_info:


### PR DESCRIPTION
Add an utility option to rec_info.py that displays per-field used memory